### PR TITLE
Update _typography.scss

### DIFF
--- a/scss/includes/_typography.scss
+++ b/scss/includes/_typography.scss
@@ -216,6 +216,7 @@ table {
 	margin: 10px 0px 15px 0px;
 	width: 100%;
 	text-align: left;
+	font-size: 0.9em;
 
 	thead {
 		text-align: center;
@@ -232,7 +233,8 @@ table {
 	td {
 		border: 0px;
 		color: #3D3D3D;
-		padding: 5px 15px;
+		/*padding: 5px 15px;*/
+		padding: 0.33em 0.85em;
 		vertical-align: top;
 	}
 


### PR DESCRIPTION
De tabel is niet goed zichtbaar in kleine mobiele schermen.
Misschien is een mediaquery voor kleine schermen een beter oplossing.

ik heb het nu even zo opgelost via Wordpress:
`<table class="table" style="font-size:0.9em">`

https://veterinaryscienceday.nl/programme/
